### PR TITLE
status sensor shouldt have device_class/state_class

### DIFF
--- a/custom_components/kostal/sensor.py
+++ b/custom_components/kostal/sensor.py
@@ -50,7 +50,8 @@ class PikoInverter(Entity):
         self.serial_number = None
         self.model = None
         # self._device_class = SENSOR_TYPES[self.type][4]
-        self._state_class = {"state_class": SENSOR_TYPES[self.type][3],"device_class":SENSOR_TYPES[self.type][4]}
+        if self._unit_of_measurement is not None:
+            self._state_class = {"state_class": SENSOR_TYPES[self.type][3],"device_class":SENSOR_TYPES[self.type][4]}
         #self.update()
 
     @property
@@ -91,7 +92,8 @@ class PikoInverter(Entity):
     @property
     def state_attributes(self):
         """Return device specific state attributes."""
-        return self._state_class
+        if self._unit_of_measurement is not None:
+            return self._state_class
 
     async def async_update(self):
         """Update data."""


### PR DESCRIPTION
Hi, status sensor was configured with device_class = None
This was giving issues with the history/logger component, nothing was tracked for recoding

Removing device_class and state_class, is working now:

![image](https://github.com/DjFabFab/kostalpiko-hacs/assets/43251136/b616b810-1a70-42ec-a579-fd6b97f12d3c)
